### PR TITLE
appveyor.yml CI config

### DIFF
--- a/WpfClipboardMonitor.sln
+++ b/WpfClipboardMonitor.sln
@@ -14,6 +14,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageCatcherOverride", "ImageCatcherOverride\ImageCatcherOverride.csproj", "{DC34D9F2-CF25-4A17-9738-34E6F5C18348}"
 EndProject
 Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "WpfClipboardMonitorDocumentation", "WpfClipboardMonitorDocumentation\WpfClipboardMonitorDocumentation.shfbproj", "{505B0644-89B7-424D-88BE-9949C6D6FF9A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{64F9FA98-B57C-4AE0-9C31-A72F74FC2D51} = {64F9FA98-B57C-4AE0-9C31-A72F74FC2D51}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/WpfClipboardMonitorDocumentation/WpfClipboardMonitorDocumentation.shfbproj
+++ b/WpfClipboardMonitorDocumentation/WpfClipboardMonitorDocumentation.shfbproj
@@ -54,6 +54,8 @@
     <CleanIntermediates>True</CleanIntermediates>
     <PlugInConfigurations>
     </PlugInConfigurations>
+    <ComponentPath>$(MSBuildThisFileDirectory)..\packages\EWSoftware.SHFB.NETFramework.4.7</ComponentPath>
+    <SHFBROOT Condition=" '$(SHFBROOT)' == '' ">$(MSBuildThisFileDirectory)..\packages\EWSoftware.SHFB.2017.5.15.0\tools\</SHFBROOT>
   </PropertyGroup>
   <!-- There are no properties for these groups.  AnyCPU needs to appear in order for Visual Studio to perform
 			 the build.  The others are optional common platform types that may appear. -->

--- a/WpfClipboardMonitorDocumentation/packages.config
+++ b/WpfClipboardMonitorDocumentation/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="EWSoftware.SHFB" version="2017.5.15.0" targetFramework="net45" />
+  <package id="EWSoftware.SHFB.NETFramework" version="4.7" targetFramework="net45" />
+</packages>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,56 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+
+environment:
+  matrix:
+    - PlatformToolset: v140
+    #- PlatformToolset: v141
+
+platform:
+    - Any CPU
+
+configuration:
+    - Release
+    #- Debug
+
+
+install:
+    - nuget restore "%APPVEYOR_BUILD_FOLDER%"\WpfClipboardMonitorDocumentation\packages.config -PackagesDirectory "%APPVEYOR_BUILD_FOLDER%"\packages
+
+
+build_script:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - msbuild WpfClipboardMonitor.sln /m /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+
+after_build:
+    - cd "%APPVEYOR_BUILD_FOLDER%"
+    - ps: >-
+        Push-AppveyorArtifact "WpfClipboardMonitor\bin\$env:CONFIGURATION\WpfClipboardMonitor.dll" -FileName WpfClipboardMonitor.dll
+
+        Push-AppveyorArtifact "ImageCatcherMember\bin\$env:CONFIGURATION\ImageCatcher.exe" -FileName ImageCatcher.exe
+
+        Push-AppveyorArtifact "WpfClipboardMonitorDocumentation\Help\WpfClipboardMonitor.chm" -FileName WpfClipboardMonitor.chm
+
+
+        if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v140") {
+            $ZipFileName = "WpfClipboardMonitor_$($env:APPVEYOR_REPO_TAG_NAME).zip"
+            7z a $ZipFileName WpfClipboardMonitor\bin\$env:CONFIGURATION\WpfClipboardMonitor.dll
+        }
+
+artifacts:
+  - path: WpfClipboardMonitor_*.zip
+    name: releases
+
+deploy:
+    provider: GitHub
+    auth_token:
+        secure: !!TODO, see https://www.appveyor.com/docs/deployment/github/#provider-settings!!
+    artifact: releases
+    draft: false
+    prerelease: false
+    force_update: true
+    on:
+        appveyor_repo_tag: true
+        PlatformToolset: v140
+        configuration: Release


### PR DESCRIPTION
- initial appveyor.yml CI config
- added sandcastle nuget packages.config to build via msbuild, see https://stackoverflow.com/questions/33668365/how-to-generate-documentation-using-sandcastle-nuget-package-ewsoftware-shfb
- added missing build dependency, needed for /m (parallel builds) option of msbuild

Build see:
https://ci.appveyor.com/project/chcg/wpfclipboardmonitor/build/1.0.10

Not done:
- prepare proper release to github, see https://www.appveyor.com/docs/deployment/github/#provider-settings
- create nuget package and publish, see https://www.codeproject.com/Tips/806257/Automating-NuGet-Package-Creation-using-AppVeyor