### PR TITLE
Appveyor3

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,0 +1,35 @@
+name: CI_build
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+    strategy:
+      max-parallel: 2
+      matrix:
+        build_configuration: [Release, Debug]
+        build_platform: [Any CPU]
+        
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v1
+
+    - name: Setup to add MSBuild.exe to path
+      uses: warrenbuckley/Setup-MSBuild@v1
+
+    - name: restore
+      working-directory: 
+      run: msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:restore /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+    - name: MSBuild of solution
+      working-directory: 
+      run: msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:WpfClipboardMonitorFramework40;WpfClipboardMonitorCore30 /p:configuration="${{ matrix.build_configuration }}" /p:platform="${{ matrix.build_platform }}"
+
+    - name: Archive artifacts
+      uses: actions/upload-artifact@v1
+      with:
+          name: WpfClipboardMonitorFramework40
+          path: WpfClipboardMonitorFramework40\bin\${{ matrix.build_configuration }}\WpfClipboardMonitor.dll
+

--- a/WpfClipboardMonitor.sln
+++ b/WpfClipboardMonitor.sln
@@ -3,8 +3,6 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29230.61
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "WpfClipboardMonitorDocumentation", "WpfClipboardMonitorDocumentation\WpfClipboardMonitorDocumentation.shfbproj", "{505B0644-89B7-424D-88BE-9949C6D6FF9A}"
-EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "WpfClipboardMonitorShare", "WpfClipboardMonitorShare\WpfClipboardMonitorShare.shproj", "{E0EC90C2-32BD-4E1F-AEFA-FB542E1604BB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfClipboardMonitorFramework40", "WpfClipboardMonitorFramework40\WpfClipboardMonitorFramework40.csproj", "{6BDDB3E3-26F2-4544-A722-D0037F804553}"
@@ -36,6 +34,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageCatcherOverrideCore30", "ImageCatcherOverrideCore30\ImageCatcherOverrideCore30.csproj", "{6434C43D-795D-44E0-B628-4E77B6DE88D1}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageCatcherOverrideFramework40", "ImageCatcherOverrideFramework40\ImageCatcherOverrideFramework40.csproj", "{5A23E36D-80D7-40BF-8CF4-53B955B62A77}"
+EndProject
+Project("{7CF6DF6D-3B04-46F8-A40B-537D21BCA0B4}") = "WpfClipboardMonitorDocumentation", "WpfClipboardMonitorDocumentation\WpfClipboardMonitorDocumentation.shfbproj", "{505B0644-89B7-424D-88BE-9949C6D6FF9A}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,10 @@
-version: 1.0.{build}
-image: Visual Studio 2017
+version: 1.1.{build}
+image: Visual Studio 2019
 
 
 environment:
   matrix:
-    #- PlatformToolset: v140
-    - PlatformToolset: v141
+    - PlatformToolset: v142
 
 platform:
     - Any CPU
@@ -18,14 +17,14 @@ configuration:
 
 build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
-    - msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:WpfClipboardMonitor;ImageCatcherEvent;ImageCatcherMember;ImageCatcherMvvm;ImageCatcherOverride /p:configuration="%configuration%" /p:platform="%platform%" /p:PlatformToolset="%PlatformToolset%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:WpfClipboardMonitorFramework40;WpfClipboardMonitorCore30;ImageCatcherEventFramework40;ImageCatcherEventCore30;ImageCatcherMemberFramework40;ImageCatcherMemberCore30;ImageCatcherMvvmFramework40;ImageCatcherMvvmCore30;ImageCatcherOverrideFramework40;ImageCatcherOverrideCore30 /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 
 # after_build:
     # - cd "%APPVEYOR_BUILD_FOLDER%"
     # - ps: >-
         # Push-AppveyorArtifact "WpfClipboardMonitor\bin\$env:CONFIGURATION\WpfClipboardMonitor.dll" -FileName WpfClipboardMonitor.dll
 
-        # if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v141") {
+        # if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v142") {
             # $ZipFileName = "WpfClipboardMonitor_$($env:APPVEYOR_REPO_TAG_NAME).zip"
             # 7z a $ZipFileName WpfClipboardMonitor\bin\$env:CONFIGURATION\WpfClipboardMonitor.dll
         # }
@@ -44,5 +43,5 @@ build_script:
     # force_update: true
     # on:
         # appveyor_repo_tag: true
-        # PlatformToolset: v141
+        # PlatformToolset: v142
         # configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,10 +2,6 @@ version: 1.1.{build}
 image: Visual Studio 2019
 
 
-environment:
-  matrix:
-    - PlatformToolset: v142
-
 platform:
     - Any CPU
 
@@ -13,18 +9,36 @@ configuration:
     - Release
     - Debug
 
+install:
+    - ps: >-
+        Start-FileDownload 'https://github.com/EWSoftware/SHFB/releases/download/v2019.9.15.0/SHFBInstaller_v2019.9.15.0.zip'
 
+        7z x -y SHFBInstaller_v2019.9.15.0.zip | Out-Null
+
+        Write-Host "Installing MSI..."
+
+        cmd /c start /wait msiexec /i InstallResources\SandcastleHelpFileBuilder.msi /quiet
+
+        Write-Host "Installing VSIX..."
+
+        . "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VSIXInstaller.exe" /q /a InstallResources\SHFBVisualStudioPackage_VS2015AndLater.vsix
+
+        Write-Host "Sandcastle installed" -ForegroundColor Green
 
 build_script:
+    - set SHFBROOT=C:\Program Files (x86)\EWSoftware\Sandcastle Help File Builder\
     - cd "%APPVEYOR_BUILD_FOLDER%"
-    - msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:WpfClipboardMonitorFramework40;WpfClipboardMonitorCore30;ImageCatcherEventFramework40;ImageCatcherEventCore30;ImageCatcherMemberFramework40;ImageCatcherMemberCore30;ImageCatcherMvvmFramework40;ImageCatcherMvvmCore30;ImageCatcherOverrideFramework40;ImageCatcherOverrideCore30 /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:restore /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+    - cd "%APPVEYOR_BUILD_FOLDER%"\Nuget
+    - if "%configuration%"=="Release" pack.cmd
 
-# after_build:
-    # - cd "%APPVEYOR_BUILD_FOLDER%"
-    # - ps: >-
-        # Push-AppveyorArtifact "WpfClipboardMonitor\bin\$env:CONFIGURATION\WpfClipboardMonitor.dll" -FileName WpfClipboardMonitor.dll
+after_build:
+     - cd "%APPVEYOR_BUILD_FOLDER%"
+     - ps: >-
+        Push-AppveyorArtifact "Nuget\WpfClipboardMonitor.1.1.0.nupkg" -FileName WpfClipboardMonitor.1.1.0.nupkg
 
-        # if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release" -and $env:PLATFORMTOOLSET -eq "v142") {
+        # if ($($env:APPVEYOR_REPO_TAG) -eq "true" -and $env:CONFIGURATION -eq "Release") {
             # $ZipFileName = "WpfClipboardMonitor_$($env:APPVEYOR_REPO_TAG_NAME).zip"
             # 7z a $ZipFileName WpfClipboardMonitor\bin\$env:CONFIGURATION\WpfClipboardMonitor.dll
         # }
@@ -43,5 +57,4 @@ build_script:
     # force_update: true
     # on:
         # appveyor_repo_tag: true
-        # PlatformToolset: v142
         # configuration: Release


### PR DESCRIPTION
- update appveyor build, see https://ci.appveyor.com/project/chcg/wpfclipboardmonitor/builds/27924884 with nuget package as artifact
-> moved sandcastle project to the end of sln, due to missing project dependencies to WpfClipboardMonitorFramework40;WpfClipboardMonitorCore30 in multithreaded build
- added github action, see https://github.com/chcg/WpfClipboardMonitor/commit/7496764b631fceb2fc6d1ed6176242bd53355344/checks?check_suite_id=254168721
, still missing for github action is sandcastle installation and build of the complete solution
