### PR TITLE
CI update

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,15 +17,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -56,9 +47,9 @@ jobs:
     - name: "Download and install sandcastle"
       run: |
            $url = "https://github.com/EWSoftware/SHFB/releases/download/v2022.12.30.0/SHFBInstaller_2022.12.30.0.zip"
-           $output = "$env:GITHUB_WORKSPACE\SHFBInstaller_v2021.4.9.0.zip"
+           $output = "$env:GITHUB_WORKSPACE\SHFBInstaller_2022.12.30.0.zip"
            (New-Object System.Net.WebClient).DownloadFile($url, $output)
-           7z x -y SHFBInstaller_v2021.4.9.0.zip | Out-Null
+           7z x -y SHFBInstaller_2022.12.30.0.zip | Out-Null
            Write-Host "Installing MSI..."
            cmd /c start /wait msiexec /i InstallResources\SandcastleHelpFileBuilder.msi /quiet
            Write-Host "Installing VSIX..."
@@ -75,6 +66,8 @@ jobs:
            Copy-Item  DummySignKey.snk -Destination Src\WpfClipboardMonitor50\Bassman.snk
            Copy-Item  DummySignKey.snk -Destination Src\WpfClipboardMonitorCore31\Bassman.snk
            Copy-Item  DummySignKey.snk -Destination Src\WpfClipboardMonitorFramework40\Bassman.snk
+           Copy-Item  DummySignKey.snk -Destination Src\WpfClipboardMonitorFramework45\Bassman.snk
+           Copy-Item  DummySignKey.snk -Destination Src\WpfClipboardMonitorFramework48\Bassman.snk
 
     - name: restore
       working-directory: .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
-version: 1.9.{build}
-image: Visual Studio 2019 Preview
+version: 1.2.0.{build}
+image: Visual Studio 2022
 
 
 platform:
@@ -10,17 +10,18 @@ configuration:
     - Debug
 
 install:
-    - nuget restore WpfClipboardMonitorPreview.sln
-
+    - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitor70\Bassman.snk
     - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitor60\Bassman.snk
     - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitor50\Bassman.snk
     - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitorCore31\Bassman.snk
     - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitorFramework40\Bassman.snk
+    - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitorFramework45\Bassman.snk
+    - copy /y "%APPVEYOR_BUILD_FOLDER%"\DummySignKey.snk "%APPVEYOR_BUILD_FOLDER%"\Src\WpfClipboardMonitorFramework48\Bassman.snk
 
     - ps: >-
-        Start-FileDownload 'https://github.com/EWSoftware/SHFB/releases/download/v2021.4.9.0/SHFBInstaller_v2021.4.9.0.zip'
+        Start-FileDownload 'https://github.com/EWSoftware/SHFB/releases/download/v2022.12.30.0/SHFBInstaller_2022.12.30.0.zip'
 
-        7z x -y SHFBInstaller_v2021.4.9.0.zip | Out-Null
+        7z x -y SHFBInstaller_2022.12.30.0.zip | Out-Null
 
         Write-Host "Installing MSI..."
 
@@ -28,20 +29,21 @@ install:
 
         Write-Host "Installing VSIX..."
 
-        . "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\Common7\IDE\VSIXInstaller.exe" /q /a InstallResources\SHFBVisualStudioPackage_VS2017AndLater.vsix
+        . "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\VSIXInstaller.exe" /q /a InstallResources\SHFBVisualStudioPackage_VS2022AndLater.vsix
 
         Write-Host "Sandcastle installed" -ForegroundColor Green
 
-build_script:
     - set SHFBROOT=C:\Program Files (x86)\EWSoftware\Sandcastle Help File Builder\
+
+    - nuget restore WpfClipboardMonitor.sln
+
+build_script:
     - cd "%APPVEYOR_BUILD_FOLDER%"
     ####- msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /t:restore /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
     - msbuild WpfClipboardMonitor.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
     ####- msbuild WpfClipboardMonitorPreview.sln /m /verbosity:minimal /t:restore /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-    - msbuild WpfClipboardMonitorPreview.sln /m /verbosity:minimal /p:configuration="%configuration%" /p:platform="%platform%" /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
     - cd "%APPVEYOR_BUILD_FOLDER%"\Nuget
     - if "%configuration%"=="Release" nuget pack WpfClipboardMonitor.nuspec -properties Configuration=Release
-    - if "%configuration%"=="Release" nuget pack WpfClipboardMonitorPreview.nuspec -properties Configuration=Release
 
 #after_build:
 #     - cd "%APPVEYOR_BUILD_FOLDER%"


### PR DESCRIPTION
- update appveyor.yml CI
- update codeql-analysis.yml CI

TODO:
- install missing .net framework sdks, but 4.0 and 4.5 is no longer available from https://dotnet.microsoft.com/en-us/download/dotnet-framework/net40 and https://dotnet.microsoft.com/en-us/download/dotnet-framework/net45 as dev pack